### PR TITLE
Fixed __len__

### DIFF
--- a/tinynumpy.py
+++ b/tinynumpy.py
@@ -554,7 +554,7 @@ class ndarray(object):
                     )
     
     def __len__(self):
-        return self.size
+        return self.shape[0]
     
     def __getitem__(self, key):
         offset, shape, strides = self._index_helper(key)


### PR DESCRIPTION
In numpy, `len(ndarray)` returns the first dimension (rows).

This is parallel to iterating over the array, which will iterate over the first dimension.