### PR TITLE
Fix setup.py modules layout

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,18 @@
 from distutils.core import setup
+
+
 setup(
-  name = 'tinynumpy',
-  packages = ['tinynumpy'], # this must be the same as the name above
-  version = '1.2.0.dev1',
-  description = 'A lightweight, pure Python, numpy compliant ndarray class',
-  author = 'Wade Brainerd, Almar Klein',
-  author_email = 'wadetb@gmail.com',
-  url = 'https://github.com/wadetb/tinynumpy', # use the URL to the github repo
-  # download_url = 'https://github.com/peterldowns/mypackage/tarball/0.1',
-  keywords = ['Science', 'Research', 'Engineering', 'Software Development'],
-  classifiers = [],
+    name='tinynumpy',
+    version='1.2.0.dev1',
+
+    description='A lightweight, pure Python, numpy compliant ndarray class',
+    author='Wade Brainerd, Almar Klein',
+    author_email='wadetb@gmail.com',
+    url='https://github.com/wadetb/tinynumpy', # use the URL to the github repo
+    # download_url='https://github.com/peterldowns/mypackage/tarball/0.1',
+    keywords=['Science', 'Research', 'Engineering', 'Software Development'],
+    classifiers=[],
+
+    py_modules=['tinynumpy', 'tinylinalg'],
+    package_dir={'': 'tinynumpy'},
 )


### PR DESCRIPTION
The whole `tinynumpy` directory was grabbed with `packages=[...]`, but
we just want to install the `tinynumpy` and `tinylinalg` modules at
top-level.

Also make setup.py more pep-8 compliant.
