### PR TITLE
Python 2 compatibility fix

### DIFF
--- a/tinynumpy/tinynumpy.py
+++ b/tinynumpy/tinynumpy.py
@@ -44,7 +44,6 @@ import sys
 import ctypes
 
 from math import sqrt
-from builtins import map
 import operator
 import tinylinalg as linalg
 from tinylinalg import LinAlgError as LinAlgError


### PR DESCRIPTION
Simply remove the `from builtins import map` import (the `builtins`
module was introduced in Python 3), since `map` is already a builtin.
