### PR TITLE
Dot and cross products

### DIFF
--- a/tinynumpy/test_tinynumpy.py
+++ b/tinynumpy/test_tinynumpy.py
@@ -245,7 +245,7 @@ def test_getitem():
 
 # Start vector cross product tests
 def test_cross():
-    """test the cross product of two 3 dimentional vectors"""
+    """test the cross product of two 3 dimensional vectors"""
 
     # Vector cross-product.
     x = [1, 2, 3]
@@ -256,7 +256,7 @@ def test_cross():
 
 
 def test_2dim_cross():
-    """test the cross product of two 2 dimentional vectors"""
+    """test the cross product of two 2 dimensional vectors"""
 
     # 2 dim cross-product.
     x = [1, 2]
@@ -269,7 +269,7 @@ def test_2dim_cross():
 
 
 def test_4dim_cross():
-    """test the cross product of two 2 dimentional vectors"""
+    """test the cross product of two 2 dimensional vectors"""
 
     # 4 dim cross-product.
     x = [1, 2, 3, 4]
@@ -282,7 +282,7 @@ def test_4dim_cross():
 
 
 def test_mdim_cross():
-    """test the cross product of two 4 dimentional vectors"""
+    """test the cross product of two 4 dimensional vectors"""
 
     # Mixed dim cross-product.
     x = [1, 2, 3]
@@ -296,7 +296,7 @@ def test_mdim_cross():
 
 # Start vector dot product tests
 def test_dot():
-    """test the dot product of two mixed dimentional vectors"""
+    """test the dot product of two mixed dimensional vectors"""
 
     # Vector dot-product.
     x = [1, 2, 3]
@@ -307,33 +307,29 @@ def test_dot():
 
 
 def test_2dim_dot():
-    """test the dot product of two 2 dimentional vectors"""
+    """test the dot product of two 2 dimensional vectors"""
 
     # 2 dim dot-product.
     x = [1, 2]
     y = [4, 5]
+    z = tnp.dot(x, y)
 
-    with pytest.raises(IndexError) as execinfo:
-        z = tnp.dot(x, y)
-
-    assert 'Vector has invalid dimensions' in str(execinfo.value)
+    assert z == 14
 
 
 def test_4dim_dot():
-    """test the dot product of two 4 dimentional vectors"""
+    """test the dot product of two 4 dimensional vectors"""
 
     # 4 dim dot-product.
     x = [1, 2, 3, 4]
     y = [5, 6, 7, 8]
+    z = tnp.dot(x, y)
 
-    with pytest.raises(IndexError) as execinfo:
-        z = tnp.dot(x, y)
-
-    assert 'Vector has invalid dimensions' in str(execinfo.value)
+    assert z == 70
 
 
 def test_mdim_dot():
-    """test the dot product of two mixed dimentional vectors"""
+    """test the dot product of two mixed dimensional vectors"""
 
     # Mixed dim dot-product.
     x = [1, 2, 3]
@@ -347,7 +343,7 @@ def test_mdim_dot():
 
 # Start vector determinant tests
 def test_det():
-    """test calculation of the determinant of a three dimentional"""
+    """test calculation of the determinant of a three dimensional"""
 
     # Three dim determinant
     x = [5, -2, 1]

--- a/tinynumpy/test_tinynumpy.py
+++ b/tinynumpy/test_tinynumpy.py
@@ -261,11 +261,9 @@ def test_2dim_cross():
     # 2 dim cross-product.
     x = [1, 2]
     y = [4, 5]
+    z = tnp.cross(x, y)
 
-    with pytest.raises(IndexError) as execinfo:
-        z = tnp.cross(x, y)
-
-    assert 'Vector has invalid dimensions' in str(execinfo.value)
+    assert z == [-3]
 
 
 def test_4dim_cross():

--- a/tinynumpy/tinynumpy.py
+++ b/tinynumpy/tinynumpy.py
@@ -399,7 +399,7 @@ def divide(ndarray_vec1, integer):
 
 def cross(u, v):
     """
-    Return the cross product of two 3 dimensional vectors.
+    Return the cross product of two 2 or 3 dimensional vectors.
     """
 
     uDim = len(u)
@@ -428,7 +428,7 @@ def cross(u, v):
 
 def dot(u, v):
     """
-    Return the dot product of two 3 dimensional vectors.
+    Return the dot product of two equal-dimensional vectors.
     """
 
     uDim = len(u)

--- a/tinynumpy/tinynumpy.py
+++ b/tinynumpy/tinynumpy.py
@@ -410,14 +410,12 @@ def cross(u, v):
     # http://mathworld.wolfram.com/CrossProduct.html
     if uDim == vDim == 2:
         try:
-            uxv.append(0)
             uxv = [u[0]*v[1]-u[1]*v[0]]            
         except LinAlgError as e:
             uxv = e        
     elif uDim == vDim == 3:
         try:
             for i in range(uDim):
-                uxv.append(0)
                 uxv = [u[1]*v[2]-u[2]*v[1], -(u[0]*v[2]-u[2]*v[0]),
                        u[0]*v[1]-u[1]*v[0]]
         except LinAlgError as e:

--- a/tinynumpy/tinynumpy.py
+++ b/tinynumpy/tinynumpy.py
@@ -408,7 +408,13 @@ def cross(u, v):
     uxv = []
 
     # http://mathworld.wolfram.com/CrossProduct.html
-    if uDim == vDim == 3:
+    if uDim == vDim == 2:
+        try:
+            uxv.append(0)
+            uxv = [u[0]*v[1]-u[1]*v[0]]            
+        except LinAlgError as e:
+            uxv = e        
+    elif uDim == vDim == 3:
         try:
             for i in range(uDim):
                 uxv.append(0)

--- a/tinynumpy/tinynumpy.py
+++ b/tinynumpy/tinynumpy.py
@@ -399,7 +399,7 @@ def divide(ndarray_vec1, integer):
 
 def cross(u, v):
     """
-    Return the cross product of two 3 dimentional vectors.
+    Return the cross product of two 3 dimensional vectors.
     """
 
     uDim = len(u)
@@ -422,14 +422,14 @@ def cross(u, v):
 
 def dot(u, v):
     """
-    Return the dot product of two 3 dimentional vectors.
+    Return the dot product of two 3 dimensional vectors.
     """
 
     uDim = len(u)
     vDim = len(v)
 
     # http://reference.wolfram.com/language/ref/Dot.html
-    if uDim == vDim == 3:
+    if uDim == vDim:
         try:
             u_dot_v = sum(map(operator.mul, u, v))
         except LinAlgError as e:


### PR DESCRIPTION
`tinynumpy.dot` and `tinynumpy.cross` functions don't perform the same as `numpy.dot` and `numpy.cross` products.

Dot product should work for any two vectors of the same length.

Cross product should work in 2- and 3-dimensions (according to `numpy` at least - actually it should also work in 7-dimensions too but `numpy` disagrees).