### PR TITLE
Fix import module for latest version of tinynumpy

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,20 +45,20 @@ Examples
 
 ```python
 
->>> import tinynumpy as tnp
+>>> from tinynumpy import tinynumpy as tnp
 
 >>> a = tnp.array([[1, 2, 3, 4],[5, 6, 7, 8]])
 
 >>> a
-array([[ 1.,  2.,  3.,  4.], 
+array([[ 1.,  2.,  3.,  4.],
     [ 5.,  6.,  7.,  8.]], dtype='float64')
 
 >>> a[:, 2:]
-array([[ 3.,  4.], 
+array([[ 3.,  4.],
     [ 7.,  8.]], dtype='float64')
 
 >>> a[:, ::2]
-array([[ 1.,  3.], 
+array([[ 1.,  3.],
     [ 5.,  7.]], dtype='float64')
 
 >>> a.shape
@@ -67,9 +67,9 @@ array([[ 1.,  3.],
 >>> a.shape = 4, 2
 
 >>> a
-array([[ 1.,  2.], 
-    [ 3.,  4.], 
-    [ 5.,  6.], 
+array([[ 1.,  2.],
+    [ 3.,  4.],
+    [ 5.,  6.],
     [ 7.,  8.]], dtype='float64')
 
 >>> b = a.ravel()


### PR DESCRIPTION
When installing the `tinynumpy` package using `pip` I am seeing that the import module structure does not match the README code example for importing the `tinynumpy` package.

This PR simply fixes the import so that the code example runs properly.

Here is a log showing the fix.

```

[sjarvie:~]$ pip install tinynumpy
Password:
Collecting tinynumpy
  Downloading https://archive.uber.com/pypi/packages/source/t/tinynumpy/tinynumpy-1.2.1.tar.gz
Installing collected packages: tinynumpy
  Running setup.py install for tinynumpy ... done
Successfully installed tinynumpy-1.2.1

[sjarvie:~]$ ipython


In [6]: import tinynumpy as tnp

In [7]:  a = tnp.array([[1, 2, 3, 4],[5, 6, 7, 8]])
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-7-9c3f2459dc0a> in <module>()
----> 1 a = tnp.array([[1, 2, 3, 4],[5, 6, 7, 8]])

AttributeError: 'module' object has no attribute 'array'

In [9]: from tinynumpy import tinynumpy as tnp

In [11]:  a = tnp.array([[1, 2, 3, 4],[5, 6, 7, 8]])

In [12]: a
Out[12]:
array([[1, 2, 3, 4],
       [5, 6, 7, 8]], dtype='int64')
```