### PR TITLE
Add GitHub workflow to build and publish package

### DIFF
--- a/.github/workflows/publish-python-package.yml
+++ b/.github/workflows/publish-python-package.yml
@@ -1,0 +1,35 @@
+name: publish
+
+on:
+  release:
+    types: [ created ]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    environment:
+      name: pypi
+      url: https://pypi.org/p/tinypypi
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+    - name: Install build tools
+      run: |
+        python -m pip install -U pip
+        python -m pip install build
+    - name: Build package
+      run: |
+        python -m build --outdir dist/ .
+    - name: Install package
+      run: python -m pip install dist/*.whl
+    - name: Run unit-tests
+      run: |
+        python -m pip install pytest
+        python -m pytest -vvra
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Solves #36 - builds wheel and sdist (using [build](https://build.pypa.io/)).

Uses trusted publishing to allow PyPI to confirm the package was built in GitHub actions.

Runs on GitHub release creation.