### PR TITLE
Modernise Python package test GitHub workflow

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,15 +12,23 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        os: [ ubuntu-latest ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12', '3.13' ]
+        include:
+        # - os: ubuntu-20.04
+        #   python-version: '3.5'
+        - os: ubuntu-20.04
+          python-version: '3.6'
+        - os: ubuntu-22.04
+          python-version: '3.7'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies


### PR DESCRIPTION
* Test with new Python versions
* Use newer versions of GitHub actions
* Disable Python 3.5 test (I wasn't able to get it to verify PyPI's TLS certificates as its cert bundle is too old)